### PR TITLE
feat: add new OptionGroup requirements and Description support

### DIFF
--- a/CleanConsole.Parse.Tests/GroupTests.cs
+++ b/CleanConsole.Parse.Tests/GroupTests.cs
@@ -8,6 +8,8 @@ public class GroupTests
     [ProgramDefinition(Name = "Test", Description = "Test")]
     [OptionGroup("Exact", OptionGroupRequirement.ExactOne)]
     [OptionGroup("AtLeast", OptionGroupRequirement.AtLeastOne)]
+    [OptionGroup("None", OptionGroupRequirement.None)]
+    [OptionGroup("AtMost", OptionGroupRequirement.AtMostOne)]
     public class GroupConfig
     {
         [Option("a", Group = "Exact")]
@@ -21,6 +23,18 @@ public class GroupTests
 
         [Option("y", Group = "AtLeast")]
         public string? Y { get; set; }
+
+        [Option("n1", Group = "None")]
+        public string? N1 { get; set; }
+
+        [Option("n2", Group = "None")]
+        public string? N2 { get; set; }
+
+        [Option("m1", Group = "AtMost")]
+        public string? M1 { get; set; }
+
+        [Option("m2", Group = "AtMost")]
+        public string? M2 { get; set; }
     }
 
     // --- ExactOne Tests ---
@@ -74,5 +88,58 @@ public class GroupTests
         var res = CleanParser.Parse<GroupConfig>(new[] { "-a:1", "-x:1", "-y:2" });
         Assert.Equal("1", res.X);
         Assert.Equal("2", res.Y);
+    }
+
+    // --- None Tests ---
+
+    [Fact]
+    public void Should_Succeed_When_None_Is_Zero()
+    {
+        var res = CleanParser.Parse<GroupConfig>(new[] { "-a:1", "-x:1" });
+        Assert.Null(res.N1);
+        Assert.Null(res.N2);
+    }
+
+    [Fact]
+    public void Should_Succeed_When_None_Is_One()
+    {
+        var res = CleanParser.Parse<GroupConfig>(new[] { "-a:1", "-x:1", "-n1:test" });
+        Assert.Equal("test", res.N1);
+        Assert.Null(res.N2);
+    }
+
+    [Fact]
+    public void Should_Succeed_When_None_Is_Many()
+    {
+        var res = CleanParser.Parse<GroupConfig>(new[] { "-a:1", "-x:1", "-n1:test1", "-n2:test2" });
+        Assert.Equal("test1", res.N1);
+        Assert.Equal("test2", res.N2);
+    }
+
+    // --- AtMostOne Tests ---
+
+    [Fact]
+    public void Should_Succeed_When_AtMostOne_Is_Zero()
+    {
+        var res = CleanParser.Parse<GroupConfig>(new[] { "-a:1", "-x:1" });
+        Assert.Null(res.M1);
+        Assert.Null(res.M2);
+    }
+
+    [Fact]
+    public void Should_Succeed_When_AtMostOne_Is_One()
+    {
+        var res = CleanParser.Parse<GroupConfig>(new[] { "-a:1", "-x:1", "-m1:test" });
+        Assert.Equal("test", res.M1);
+        Assert.Null(res.M2);
+    }
+
+    [Fact]
+    public void Should_Throw_When_AtMostOne_Is_Many()
+    {
+        var ex = Assert.Throws<CleanParserException>(() => 
+            CleanParser.Parse<GroupConfig>(new[] { "-a:1", "-x:1", "-m1:test1", "-m2:test2" }));
+        Assert.Contains("permite no máximo uma opção", ex.Message);
+        Assert.Contains("foram fornecidas: 2", ex.Message);
     }
 }

--- a/CleanConsole.Parse.Tests/HelpTests.cs
+++ b/CleanConsole.Parse.Tests/HelpTests.cs
@@ -26,4 +26,35 @@ public class HelpTests
         Assert.Contains("-f", help);
         Assert.Contains("--verbose", help);
     }
+
+    [ProgramDefinition(Name = "DetailedApp", Description = "App description")]
+    [OptionGroup("Output", OptionGroupRequirement.None, Description = "Output settings")]
+    public class DetailedHelpConfig
+    {
+        [Option("input", ShortOptionName = "i", Description = "Input file path")]
+        public string? Input { get; set; }
+
+        [Option("format", Group = "Output", Description = "Output format")]
+        public string? Format { get; set; }
+    }
+
+    [Fact]
+    public void Should_Include_Descriptions_And_Groups_In_Help()
+    {
+        var help = CleanParser.GetHelpText<DetailedHelpConfig>();
+
+        Assert.Contains("DetailedApp", help);
+        Assert.Contains("App description", help);
+        
+        // Check Option Description
+        Assert.Contains("Input file path", help);
+        
+        // Check Group presence and description
+        Assert.Contains("Group: Output", help);
+        Assert.Contains("(Requirement: None)", help);
+        Assert.Contains("Output settings", help);
+        
+        // Check grouped option
+        Assert.Contains("Output format", help);
+    }
 }

--- a/CleanConsole.Parse/Attributes/OptionAttribute.cs
+++ b/CleanConsole.Parse/Attributes/OptionAttribute.cs
@@ -27,6 +27,12 @@ public sealed class OptionAttribute : Attribute
     public string? Group { get; set; }
 
     /// <summary>
+    /// A brief description of what this option does.
+    /// Used when generating help text.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="OptionAttribute"/> class.
     /// </summary>
     /// <param name="optionName">The mandatory long name of the option.</param>

--- a/CleanConsole.Parse/Attributes/OptionGroupAttribute.cs
+++ b/CleanConsole.Parse/Attributes/OptionGroupAttribute.cs
@@ -20,6 +20,12 @@ public sealed class OptionGroupAttribute : Attribute
     public OptionGroupRequirement Require { get; }
 
     /// <summary>
+    /// A brief description of what this group represents.
+    /// Used when generating help text.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="OptionGroupAttribute"/> class.
     /// </summary>
     /// <param name="name">The unique name of the group.</param>

--- a/CleanConsole.Parse/CleanParser.cs
+++ b/CleanConsole.Parse/CleanParser.cs
@@ -192,6 +192,7 @@ public static class CleanParser
     {
         var type = typeof(T);
         var programDef = type.GetCustomAttribute<ProgramDefinitionAttribute>();
+        var definedGroups = type.GetCustomAttributes<OptionGroupAttribute>().ToDictionary(g => g.Name);
         var sb = new StringBuilder();
 
         if (programDef != null)
@@ -205,32 +206,73 @@ public static class CleanParser
             sb.AppendLine();
         }
 
-        sb.AppendLine("Options:");
-
         var properties = type.GetProperties();
+        
+        var ungroupedOptions = new List<PropertyInfo>();
+        var groupedOptions = new Dictionary<string, List<PropertyInfo>>();
+
         foreach (var prop in properties)
         {
             var opt = prop.GetCustomAttribute<OptionAttribute>();
             if (opt == null) continue;
 
-            var shortName = !string.IsNullOrEmpty(opt.ShortOptionName) ? $"-{opt.ShortOptionName}, " : "    ";
-            var longName = $"--{opt.OptionName}";
-            
-            var line = $"  {shortName}{longName}";
-            
-            // Padding para alinhar
-            if (line.Length < 30)
-                line = line.PadRight(30);
-            
-            if (!string.IsNullOrEmpty(opt.Group))
+            if (!string.IsNullOrEmpty(opt.Group) && definedGroups.ContainsKey(opt.Group))
             {
-                line += $" [Group: {opt.Group}]";
+                if (!groupedOptions.ContainsKey(opt.Group))
+                    groupedOptions[opt.Group] = new List<PropertyInfo>();
+                
+                groupedOptions[opt.Group].Add(prop);
             }
-
-            sb.AppendLine(line);
+            else
+            {
+                ungroupedOptions.Add(prop);
+            }
         }
 
-        return sb.ToString();
+        if (ungroupedOptions.Any())
+        {
+            sb.AppendLine("Options:");
+            foreach (var prop in ungroupedOptions)
+            {
+                sb.AppendLine(FormatOptionLine(prop));
+            }
+            sb.AppendLine();
+        }
+
+        foreach (var groupName in groupedOptions.Keys)
+        {
+            var groupAttr = definedGroups[groupName];
+            var groupDesc = !string.IsNullOrEmpty(groupAttr.Description) ? $" - {groupAttr.Description}" : "";
+            sb.AppendLine($"Group: {groupName} (Requirement: {groupAttr.Require}){groupDesc}");
+            
+            foreach (var prop in groupedOptions[groupName])
+            {
+                sb.AppendLine(FormatOptionLine(prop));
+            }
+            sb.AppendLine();
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string FormatOptionLine(PropertyInfo prop)
+    {
+        var opt = prop.GetCustomAttribute<OptionAttribute>();
+        var shortName = !string.IsNullOrEmpty(opt!.ShortOptionName) ? $"-{opt.ShortOptionName}, " : "    ";
+        var longName = $"--{opt.OptionName}";
+        
+        var line = $"  {shortName}{longName}";
+        
+        // Padding para alinhar
+        if (line.Length < 30)
+            line = line.PadRight(30);
+        
+        if (!string.IsNullOrEmpty(opt.Description))
+        {
+            line += $"{opt.Description}";
+        }
+
+        return line;
     }
 
     private static void PrintSummary<T>(T instance, PropertyInfo[] properties)

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ using CleanConsole.Parse;
 [ProgramDefinition(Name = "FileCompressor", Description = "Ferramenta CLI para compressão de arquivos.")]
 public class CompressionOptions
 {
-    [Option(OptionName = "input", ShortOptionName = "i")]
+    [Option("input", ShortOptionName = "i", Description = "Caminho do arquivo de entrada")]
     public string InputFile { get; set; }
 
-    [Option(OptionName = "level")]
+    [Option("level", Description = "Nível de compressão (1-9)")]
     public int CompressionLevel { get; set; } = 5; // Valor padrão
 
-    [Option(OptionName = "verbose", ShortOptionName = "v")]
+    [Option("verbose", ShortOptionName = "v", Description = "Habilita logs detalhados")]
     public bool Verbose { get; set; }
 }
 ```

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -23,6 +23,7 @@ Marca uma propriedade para ser preenchida via argumento de linha de comando.
 | `OptionName` | `string` | Sim | O nome longo do argumento (ex: `port` para `--port`). **Não use prefixos.** |
 | `ShortOptionName` | `string` | Não | O alias curto (ex: `p` para `-p`). **Não use prefixos.** |
 | `Group` | `string` | Não | Nome do grupo de validação ao qual esta opção pertence. |
+| `Description` | `string` | Não | Descrição da opção para exibição na ajuda. |
 
 **Tipos Suportados:**
 *   `string`
@@ -40,6 +41,7 @@ O construtor aceita o nome do grupo e seu requisito de validação.
 | :--- | :--- | :--- | :--- |
 | `name` | `string` | Sim | Identificador único do grupo (referenciado em `[Option]`). |
 | `require` | `OptionGroupRequirement` | Sim | A regra de validação a ser aplicada (`ExactOne`, `AtLeastOne`, `None`, ou `AtMostOne`). |
+| `Description` | `string` | Não | Descrição do grupo para exibição na ajuda. |
 
 ## Enums
 

--- a/plans/new_grouping_types.md
+++ b/plans/new_grouping_types.md
@@ -33,9 +33,9 @@ O plano de tarefas foi completamente reestruturado em Épicos para refletir uma 
 |:---|:---|:---|:---|
 | R-01 | Unificar todos os namespaces para `CleanConsole.Parse`. | Architect | Concluído |
 | R-02 | Renomear atributo `ProgramDef` para `ProgramDefinition` e seu arquivo. | Architect | Concluído |
-| R-03 | No atributo `[OptionGroup]`, renomear a propriedade `Type` para `Require`. | Architect | Pendente |
-| R-04 | Adicionar a propriedade `string Description` ao `[OptionAttribute]`. | Architect | Pendente |
-| R-05 | Adicionar a propriedade `string Description` ao `[OptionGroupAttribute]`. | Architect | Pendente |
+| R-03 | No atributo `[OptionGroup]`, renomear a propriedade `Type` para `Require`. | Architect | Concluído |
+| R-04 | Adicionar a propriedade `string Description` ao `[OptionAttribute]`. | Architect | Concluído |
+| R-05 | Adicionar a propriedade `string Description` ao `[OptionGroupAttribute]`. | Architect | Concluído |
 | R-06 | **(Cancelado)** Mover `OptionGroupRequirement.cs` da pasta `Enums` para a raiz. | Architect | Cancelado |
 
 #### **Épico 2: Implementação dos Novos Tipos de Grupo**
@@ -43,41 +43,44 @@ O plano de tarefas foi completamente reestruturado em Épicos para refletir uma 
 
 | ID | Tarefa | Responsável | Status |
 |:---|:---|:---|:---|
-| F-01 | Atualizar o enum `OptionGroupRequirement` com os valores `None` e `AtMostOne`. | Core Eng | Pendente |
-| F-02 | Implementar a lógica de validação para `None` no `CleanParser`. | Core Eng | Pendente |
-| F-03 | Implementar a lógica de validação para `AtMostOne` no `CleanParser`. | Core Eng | Pendente |
+| F-01 | Atualizar o enum `OptionGroupRequirement` com os valores `None` e `AtMostOne`. | Core Eng | Concluído |
+| F-02 | Implementar a lógica de validação para `None` no `CleanParser`. | Core Eng | Concluído |
+| F-03 | Implementar a lógica de validação para `AtMostOne` no `CleanParser`. | Core Eng | Concluído |
 
 #### **Épico 3: Experiência do Usuário (UX) e Geração de Ajuda**
 *Objetivo: Garantir que a saída do console (ajuda e erros) seja clara e informativa.*
 
 | ID | Tarefa | Responsável | Status |
 |:---|:---|:---|:---|
-| UX-01 | Desenhar o formato de exibição do texto de ajuda (`--help`) para os grupos, incluindo suas `Description` e requisito (`None`, `AtMostOne`, etc.). | UX Specialist | Pendente |
-| UX-02 | Desenhar a mensagem de erro específica para a violação da regra `AtMostOne`. | UX Specialist | Pendente |
-| UX-03 | Implementar a nova geração de `GetHelpText` para refletir o design da tarefa UX-01. | Core Eng | Pendente |
+| UX-01 | Desenhar o formato de exibição do texto de ajuda (`--help`) para os grupos, incluindo suas `Description` e requisito (`None`, `AtMostOne`, etc.). | UX Specialist | Concluído |
+| UX-02 | Desenhar a mensagem de erro específica para a violação da regra `AtMostOne`. | UX Specialist | Concluído |
+| UX-03 | Implementar a nova geração de `GetHelpText` para refletir o design da tarefa UX-01. | Core Eng | Concluído |
 
 #### **Épico 4: Testes e Garantia de Qualidade (QA)**
 *Objetivo: Assegurar que as novas funcionalidades e refatorações sejam robustas e não introduzam regressões.*
 
 | ID | Tarefa | Responsável | Status |
 |:---|:---|:---|:---|
-| T-01 | Criar testes unitários para o requisito de grupo `None`. | QA Eng | Pendente |
-| T-02 | Criar testes unitários para o requisito de grupo `AtMostOne` (sucesso e falha). | QA Eng | Pendente |
-| T-03 | Criar teste unitário que valide a nova mensagem de erro da tarefa UX-02. | QA Eng | Pendente |
-| T-04 | Criar testes para verificar se a `Description` de `[Option]` e `[OptionGroup]` aparece no `GetHelpText`. | QA Eng | Pendente |
-| T-05 | Criar testes para as refatorações de nomenclatura (`ProgramDefinition`, `Require`). | QA Eng | Pendente |
+| T-01 | Criar testes unitários para o requisito de grupo `None`. | QA Eng | Concluído |
+| T-02 | Criar testes unitários para o requisito de grupo `AtMostOne` (sucesso e falha). | QA Eng | Concluído |
+| T-03 | Criar teste unitário que valide a nova mensagem de erro da tarefa UX-02. | QA Eng | Concluído |
+| T-04 | Criar testes para verificar se a `Description` de `[Option]` e `[OptionGroup]` aparece no `GetHelpText`. | QA Eng | Concluído |
+| T-05 | Criar testes para as refatorações de nomenclatura (`ProgramDefinition`, `Require`). | QA Eng | Concluído |
 
 #### **Épico 5: Documentação e Finalização**
 *Objetivo: Realizar a revisão final e atualizar toda a documentação do projeto para refletir as mudanças.*
 
 | ID | Tarefa | Responsável | Status |
 |:---|:---|:---|:---|
-| D-01 | Realizar a Revisão de Código (Code Review) de todas as implementações. | Architect | Pendente |
-| D-02 | Atualizar `docs/API_REFERENCE.md` com todas as mudanças na API (atributos, propriedades e enums). | Architect | Pendente |
-| D-03 | Atualizar `README.md` com exemplos das novas funcionalidades. | Architect | Pendente |
-| D-04 | Atualizar `PRD.md` para refletir a nova arquitetura de namespace único e as novas funcionalidades. | Architect | Pendente |
-| D-05 | Adicionar exemplos de uso dos novos tipos de grupo em `docs/BEST_PRACTICES.md` ou `GETTING_STARTED.md`. | Architect | Pendente |
-| D-06 | Revisar e atualizar os arquivos em `agents/` se a refatoração da API impactar as responsabilidades. | Architect | Pendente |
+| D-01 | Realizar a Revisão de Código (Code Review) de todas as implementações. | Architect | Concluído |
+| D-02 | Atualizar `docs/API_REFERENCE.md` com todas as mudanças na API (atributos, propriedades e enums). | Architect | Concluído |
+| D-03 | Atualizar `README.md` com exemplos das novas funcionalidades. | Architect | Concluído |
+| D-04 | Atualizar `PRD.md` para refletir a nova arquitetura de namespace único e as novas funcionalidades. | Architect | Cancelado |
+| D-05 | Adicionar exemplos de uso dos novos tipos de grupo em `docs/BEST_PRACTICES.md` ou `GETTING_STARTED.md`. | Architect | Concluído |
+| D-06 | Revisar e atualizar os arquivos em `agents/` se a refatoração da API impactar as responsabilidades. | Architect | Concluído |
+| D-07 | Remover `tarefas.md`. | Architect | Concluído |
+| D-08 | Remover `PRD.md`. | Architect | Concluído |
+| D-09 | Remover referências a `tarefas.md` e `PRD.md` de todos os arquivos do projeto. | Architect | Concluído |
 
 ---
 *Aprovado por:* Solutions Architect


### PR DESCRIPTION
- Added 'None' and 'AtMostOne' to OptionGroupRequirement enum.
- Implemented validation logic for new group requirements in CleanParser.
- Added 'Description' property to OptionAttribute and OptionGroupAttribute.
- Refactored 'GetHelpText' to display option/group descriptions and requirements.
- Added unit tests for new group types and help text generation.
- Updated API reference and README documentation.
- Marked all tasks as completed in plans/new_grouping_types.md.